### PR TITLE
feat: Add GitHub Actions CI workflow for Elixir project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Elixir CI
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test-latest:
+    strategy:
+      matrix:
+        include:
+          - os: macos-14-xlarge
+            elixir-version: '1.18.4'
+            otp-version: '28.0.1'
+
+    name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: jdx/mise-action@v2
+      with:
+        version: '2025.7.2'
+        install: true
+        cache: true
+        experimental: true
+        log_level: debug
+        tool_versions: |
+            erlang: 28.0.1
+            elixir: 1.18.4-otp-28
+    - run: mix test


### PR DESCRIPTION
- Add CI workflow for Elixir 1.18.4 with OTP 28.0.1
- Configure workflow to run on macOS 14 with large runners
- Use mise-action for tool version management
- Set up concurrent job handling with automatic cancellation
- Configure workflow to trigger on main/develop branches and PRs
- Exclude markdown and license files from CI triggers
- Set 5-minute timeout for build jobs
- Run mix test as the primary CI step